### PR TITLE
Fixed issue with font

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:wght@200;400&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter+Tight:wght@200;400&display=swap");
 
 @font-face {
     font-family: 'queengrunge';
-    src: url(./resources/fonts/QueenInlineGrunge.ttf) format("truetype");
+    src: url("./resources/fonts/QueenInlineGrunge.ttf") format("truetype");
 }
 
 .colors {


### PR DESCRIPTION
Github pages was not showing the correct font, it was because the path pointing to the font was not enclosed in quotemarks.